### PR TITLE
Add fetch categories end point from wordpress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>consulting.pigott.wordpress</groupId>
     <artifactId>wordpress-sdk</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Pigott Consulting Wordpress SDK</description>

--- a/src/main/java/consulting/pigott/wordpress/WordpressClient.java
+++ b/src/main/java/consulting/pigott/wordpress/WordpressClient.java
@@ -1,5 +1,6 @@
 package consulting.pigott.wordpress;
 
+import consulting.pigott.wordpress.model.Category;
 import consulting.pigott.wordpress.model.Media;
 import consulting.pigott.wordpress.model.PagedResponse;
 import consulting.pigott.wordpress.model.Post;
@@ -37,4 +38,10 @@ public interface WordpressClient {
     Media updateMedia(Media media) throws IOException, URISyntaxException;
 
     void deleteMedia(String id) throws IOException, URISyntaxException;
+
+    //==============  Category  ===================//
+
+    List<Category> getAllCategories(Optional<Map<String, String>> queryParams) throws IOException, URISyntaxException;
+
+    PagedResponse<Category> getCategories(Integer page, Integer perPage, Optional<Map<String, String>> queryParams) throws IOException, URISyntaxException;
 }

--- a/src/main/java/consulting/pigott/wordpress/WordpressClientImpl.java
+++ b/src/main/java/consulting/pigott/wordpress/WordpressClientImpl.java
@@ -249,6 +249,10 @@ public class WordpressClientImpl implements WordpressClient {
         while (!lastPage) {
 
             PagedResponse<T> response = getter.get(pageNum, 20,queryParams);
+            if (response.getPages() == null) {
+                response.setPages(0);
+                response.setTotal(0);
+            }
 
             entities.addAll(response);
             if (pageNum < response.getPages()) {

--- a/src/main/java/consulting/pigott/wordpress/WordpressClientImpl.java
+++ b/src/main/java/consulting/pigott/wordpress/WordpressClientImpl.java
@@ -2,10 +2,7 @@ package consulting.pigott.wordpress;
 
 import consulting.pigott.wordpress.authentication.AuthenticationProvider;
 import consulting.pigott.wordpress.config.Config;
-import consulting.pigott.wordpress.model.JsonViews;
-import consulting.pigott.wordpress.model.Media;
-import consulting.pigott.wordpress.model.PagedResponse;
-import consulting.pigott.wordpress.model.Post;
+import consulting.pigott.wordpress.model.*;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -219,6 +216,29 @@ public class WordpressClientImpl implements WordpressClient {
                 JsonViews.Read.class);
     }
 
+    //==============  Category  ===================//
+
+    @Override
+    public List<Category> getAllCategories(Optional<Map<String, String>> queryParams) throws IOException, URISyntaxException {
+        return getAll(this::getCategories, queryParams);
+    }
+
+    @Override
+    public PagedResponse<Category> getCategories(Integer page, Integer perPage, Optional<Map<String, String>> queryParams) throws IOException, URISyntaxException {
+        URIBuilder builder = this.makeBaseURIBuilder(page, perPage)
+                .setPathSegments("wp-json", "wp", "v2", "categories");
+
+        if (queryParams.isPresent()) {
+            for (String key : queryParams.get().keySet()) {
+                builder.addParameter(key, queryParams.get().get(key));
+            }
+        }
+
+        return this.executeList(
+                this.makeStandardRequest(new HttpGet(builder.build().toURL().toString())),
+                Category.class,
+                JsonViews.Read.class);
+    }
 
     //================= Support Methods  ==================//
 
@@ -229,10 +249,6 @@ public class WordpressClientImpl implements WordpressClient {
         while (!lastPage) {
 
             PagedResponse<T> response = getter.get(pageNum, 20,queryParams);
-            if (response.getPages() == null) {
-                response.setPages(0);
-                response.setTotal(0);
-            }
 
             entities.addAll(response);
             if (pageNum < response.getPages()) {
@@ -286,14 +302,6 @@ public class WordpressClientImpl implements WordpressClient {
 
         pagedResponse.addAll(entries);
         return pagedResponse;
-    }
-
-    public void setHttpClient(HttpClient httpClient) {
-        this.httpClient = httpClient;
-    }
-
-    public HttpClient getHttpClient() {
-        return httpClient;
     }
 
 

--- a/src/main/java/consulting/pigott/wordpress/model/Category.java
+++ b/src/main/java/consulting/pigott/wordpress/model/Category.java
@@ -1,0 +1,47 @@
+package consulting.pigott.wordpress.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    @JsonProperty("id")
+    @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
+    private Integer id;
+
+    @JsonProperty("link")
+    @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
+    private Integer count;
+
+    @JsonProperty("link")
+    @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
+    private String description;
+
+    @JsonProperty("link")
+    @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
+    private String link;
+
+    @JsonProperty("name")
+    @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
+    private String name;
+
+    @JsonProperty("taxonomy")
+    @JsonView({JsonViews.Read.class})
+    private String taxonomy;
+
+    @JsonProperty("parent")
+    @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
+    private Integer parent;
+
+    @JsonProperty("meta")
+    @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
+    private Meta meta;
+}


### PR DESCRIPTION
For tech debt story.

Currently we need to manually add new categories in config files if a new category is added.
We want to be able to get categories on the fly, in order to fetch the latest changes
