### PR TITLE
CP-1206: Modify category model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>consulting.pigott.wordpress</groupId>
     <artifactId>wordpress-sdk</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Pigott Consulting Wordpress SDK</description>

--- a/src/main/java/consulting/pigott/wordpress/model/Category.java
+++ b/src/main/java/consulting/pigott/wordpress/model/Category.java
@@ -17,11 +17,11 @@ public class Category {
     @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
     private Integer id;
 
-    @JsonProperty("link")
+    @JsonProperty("count")
     @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
     private Integer count;
 
-    @JsonProperty("link")
+    @JsonProperty("description")
     @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
     private String description;
 
@@ -40,8 +40,4 @@ public class Category {
     @JsonProperty("parent")
     @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
     private Integer parent;
-
-    @JsonProperty("meta")
-    @JsonView({JsonViews.Read.class, JsonViews.Edit.class})
-    private Meta meta;
 }


### PR DESCRIPTION
This changeset is still for the same purpose of bring wp blog categories from local to live retrieval. 